### PR TITLE
ci(publish-npm.yml): pnpm publish -> npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -40,7 +40,7 @@ jobs:
 
       - run: pnpm install
 
-      - run: pnpm publish
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Migrates publish cmd to npm as pnpm can't detect the branch name